### PR TITLE
linux-tq: make localversion deterministic

### DIFF
--- a/meta-tq/recipes-kernel/linux/linux-tq.inc
+++ b/meta-tq/recipes-kernel/linux/linux-tq.inc
@@ -37,10 +37,11 @@ KCONFIG_MODE="--alldefconfig"
 # and without linux-yocto.
 ####
 do_set_localversion_tq() {
-    head=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-parse --short HEAD 2> /dev/null)
-    printf '%s%s%s\n' "${KERNEL_LOCALVERSION}" +g ${head} > ${STAGING_KERNEL_DIR}/localversion-tq
+    head=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-parse --short ${SRCREV} 2> /dev/null)
+    patches=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-list --count ${SRCREV}..HEAD 2> /dev/null)
+    printf '%s%s%s%s%s\n' "${KERNEL_LOCALVERSION}" +g ${head} +p ${patches} > ${STAGING_KERNEL_DIR}/localversion-tq
 }
-addtask set_localversion_tq before do_patch do_configure after do_symlink_kernsrc do_kernel_metadata
+addtask set_localversion_tq before do_configure after do_patch do_symlink_kernsrc do_kernel_metadata
 
 S = "${WORKDIR}/git"
 

--- a/meta-tq/recipes-kernel/linux/linux-tq.inc
+++ b/meta-tq/recipes-kernel/linux/linux-tq.inc
@@ -37,8 +37,18 @@ KCONFIG_MODE="--alldefconfig"
 # and without linux-yocto.
 ####
 do_set_localversion_tq() {
-    head=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-parse --short ${SRCREV} 2> /dev/null)
-    patches=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-list --count ${SRCREV}..HEAD 2> /dev/null)
+    if [ "${SRCREV}" = "INVALID" ]; then
+        hash=${SRCREV_machine}
+    else
+        hash=${SRCREV}
+    fi
+    if [ "$hash" = "AUTOINC" ]; then
+        branch=$(git --git-dir=${STAGING_KERNEL_DIR}/.git  symbolic-ref --short -q HEAD)
+        head=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-parse --verify --short origin/${branch} 2> /dev/null)
+    else
+        head=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-parse --verify --short ${hash} 2> /dev/null)
+    fi
+    patches=$(git --git-dir=${STAGING_KERNEL_DIR}/.git rev-list --count ${head}..HEAD 2> /dev/null)
     printf '%s%s%s%s%s\n' "${KERNEL_LOCALVERSION}" +g ${head} +p ${patches} > ${STAGING_KERNEL_DIR}/localversion-tq
 }
 addtask set_localversion_tq before do_configure after do_patch do_symlink_kernsrc do_kernel_metadata


### PR DESCRIPTION
The localversion string built into the kernel should be deterministic. With OpenEmbedded it is common practice to apply patches to the sources. The commit id of HEAD will differ each time the patching step is rerun. With the previous implementation of the do_set_localversion_tq task this produced non-deterministic commit ids to be used. This is undesireable, because the commit id read from the version string during runtime is not present in the sources. It also caused problems when building out- of-tree kernel-modules if the kernel itself was taken from sstate cache but the kernel-module needed to be rebuild and retriggered the kernels do_patch task (see this issue in meta-freescale, that was due to a similar localversion modification
https://github.com/Freescale/meta-freescale/issues/961).

Rework to produce a deterministic string that will use the commit id given as SRCREV and count the number of patches applied on top.

With e.g. commit id 11aabbcc and 5 patches this will result in a version string
  +g11aabbcc+p5

Related: https://github.com/Freescale/meta-freescale/pull/1694